### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TylerDev888/CodeDesignerAI/security/code-scanning/1](https://github.com/TylerDev888/CodeDesignerAI/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block either at the workflow root (to apply to all jobs) or under the specific job, granting only the minimal scopes required. For a CI build that just checks out code, restores dependencies, and builds, `contents: read` is sufficient in almost all cases.

The best way to fix this workflow without changing existing functionality is to add a top‑level `permissions` block right after the `name: CI` line. This will apply to all jobs (currently just `build`) that do not override permissions. We set `contents: read`, which allows `actions/checkout` to read the repository while preventing write operations via `GITHUB_TOKEN`. No other scopes (like `pull-requests` or `issues`) are needed based on the shown steps, and we are not introducing any new external libraries.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`). No other lines in this file need to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
